### PR TITLE
Fix carousel reset bug

### DIFF
--- a/projeto Cafe quente/public/FrontAddons/JS/main/carrossel.js
+++ b/projeto Cafe quente/public/FrontAddons/JS/main/carrossel.js
@@ -198,7 +198,9 @@ function stopInactivityTimer() {
  * Mostra o carrossel após período de inatividade
  */
 function showCarrossel() {
-    localStorage.removeItem("nomeCliente", "pedido")
+    // Limpa os dados do usuário para reiniciar o totem após a inatividade
+    localStorage.removeItem("nomeCliente");
+    localStorage.removeItem("pedido");
     const carrossel = document.getElementById("carroça");
     if (carrossel) {
         console.log("📺 Mostrando carrossel por inatividade");


### PR DESCRIPTION
## Summary
- clear stored user info correctly when carousel is shown

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68712a3168a08324be062fccb892d5b6